### PR TITLE
fix: override baseURL in Nitro

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,10 @@ function adaptElectronConfig(options: ElectronOptions, nuxt: Nuxt) {
     nuxt.options.runtimeConfig.app.baseURL = './' // '/'
     nuxt.options.runtimeConfig.app.buildAssetsDir = '/' // '/_nuxt/'
 
-    nuxt.options.nitro.runtimeConfig.app.baseURL = './'
+    // Only apply on build
+    if (!nuxt.options.dev) {
+      nuxt.options.nitro.runtimeConfig.app.baseURL = './'
+    }
 
     nuxt.options.router.options.hashMode ??= true // Avoid 404 errors
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,8 @@ function adaptElectronConfig(options: ElectronOptions, nuxt: Nuxt) {
     nuxt.options.runtimeConfig.app.baseURL = './' // '/'
     nuxt.options.runtimeConfig.app.buildAssetsDir = '/' // '/_nuxt/'
 
+    nuxt.options.nitro.runtimeConfig.app.baseURL = './'
+
     nuxt.options.router.options.hashMode ??= true // Avoid 404 errors
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,13 @@ export interface ElectronOptions {
    *       buildAssetsDir: '/',
    *     },
    *   },
+   *   nitro: {
+   *     runtimeConfig: {
+   *       app: {
+   *         baseURL: './,
+   *       }
+  *      }
+   *   },
    * })
    * ```
    */


### PR DESCRIPTION
https://github.com/nuxt/nuxt/pull/23841 breaks this package when building and running the app in production.

Setting `nitro.runtimeConfig.app.baseURL` to `./` will fix the problem, making `nuxt-electron` compatible with Nuxt 3.8.1 and up.