### PR TITLE
Fixes 404 error by explicitly setting hashMode = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ export interface ElectronOptions {
    *       }
   *      }
    *   },
+      router: {
+        options: {
+          hashMode: true,
+        }
+      }
    * })
    * ```
    */

--- a/examples/quick-start/nuxt.config.ts
+++ b/examples/quick-start/nuxt.config.ts
@@ -16,5 +16,5 @@ export default defineNuxtConfig({
       },
     ],
     renderer: {},
-  },
+  }
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ function adaptElectronConfig(options: ElectronOptions, nuxt: Nuxt) {
 
     nuxt.options.runtimeConfig.app.baseURL = './' // '/'
     nuxt.options.runtimeConfig.app.buildAssetsDir = '/' // '/_nuxt/'
+    nuxt.options.router.options.hashMode = true // Avoid 404 errors
 
     // Only apply on build
     if (!nuxt.options.dev) {
@@ -182,6 +183,5 @@ function adaptElectronConfig(options: ElectronOptions, nuxt: Nuxt) {
       nuxt.options.nitro.runtimeConfig.app.baseURL = './'
     }
 
-    nuxt.options.router.options.hashMode = true // Avoid 404 errors
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,6 @@ function adaptElectronConfig(options: ElectronOptions, nuxt: Nuxt) {
       nuxt.options.nitro.runtimeConfig.app.baseURL = './'
     }
 
-    nuxt.options.router.options.hashMode ??= true // Avoid 404 errors
+    nuxt.options.router.options.hashMode = true // Avoid 404 errors
   }
 }


### PR DESCRIPTION
The default `nuxt.options.router.options.hashMode` = `false`.

Therefore, the previous coalescing assignment does nothing. It doesn't disable default opts as the `disableDefaultOptions` intends (I think?).

This explicitly sets the value to true, in order to overcome the 404 on build.