### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@
 
 ```sh
 # Using pnpm
-pnpm add -D nuxt-electron vite-plugin-electron vite-plugin-electron-renderer electron electron-builder
+npx nuxi@latest module add electron
 ```
 
 ```sh
 # Using yarn
-yarn add --dev nuxt-electron vite-plugin-electron vite-plugin-electron-renderer electron electron-builder
+npx nuxi@latest module add electron
 ```
 
 ```sh
 # Using npm
-npm install --save-dev nuxt-electron vite-plugin-electron vite-plugin-electron-renderer electron electron-builder
+npx nuxi@latest module add electron
 ```
 
 2. Add `nuxt-electron` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -21,17 +21,6 @@
 1. Add the following dependency to your project
 
 ```sh
-# Using pnpm
-npx nuxi@latest module add electron
-```
-
-```sh
-# Using yarn
-npx nuxi@latest module add electron
-```
-
-```sh
-# Using npm
 npx nuxi@latest module add electron
 ```
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
